### PR TITLE
Remove temporary menus and retain color animated nodes

### DIFF
--- a/NetworkViewMenu.xml
+++ b/NetworkViewMenu.xml
@@ -4,28 +4,8 @@
         <subMenu id="BYVFX_Tools">
             <modifyItem><insertBefore>help_menu</insertBefore></modifyItem>
             <label>BYVFX_Tools</label>
-            
-            <subMenu id="modeling_tools">
-                <label>Modeling</label>
-                <scriptItem id="tool_1">
-                    <label>Modeling Tool 1</label>
-                </scriptItem>
-                <scriptItem id="tool_2">
-                    <label>Modeling Tool 2</label>
-                </scriptItem>
-            </subMenu>
 
-            <subMenu id="fx_tools">
-                <label>FX</label>
-                <scriptItem id="fx_1">
-                    <label>FX Tool 1</label>
-                </scriptItem>
-                <scriptItem id="fx_2">
-                    <label>FX Tool 2</label>
-                </scriptItem>
-            </subMenu>
-
-            <subMenu id="utility_tools">
+            <subMenu id="Utilities">
                 <label>Utilities</label>
                 <scriptItem id="Color_Animated_Nodes">
                     <label>Color Animated Nodes</label>
@@ -39,11 +19,7 @@ else:
 color_anim_nodes.color_animated_nodes()
 ]]></scriptCode>
                 </scriptItem>
-                <scriptItem id="util_2">
-                    <label>Utility Tool 2</label>
-                </scriptItem>
             </subMenu>
-
         </subMenu>
     </menuBar>
 </mainMenu>


### PR DESCRIPTION
Eliminate unnecessary temporary menus, focusing on the color animated nodes for a cleaner interface.