### PR TITLE
Add error check for animated nodes and keyframes

### DIFF
--- a/python3.11libs/byvfx/utils/color_anim_nodes.py
+++ b/python3.11libs/byvfx/utils/color_anim_nodes.py
@@ -2,18 +2,27 @@ import hou
 
 def color_animated_nodes():
     """Colorizes nodes with keyframes in the current network editor."""
-    user_color = hou.ui.selectColor()
-    if user_color is None:
-        return
-
+    
     network = hou.ui.paneTabOfType(hou.paneTabType.NetworkEditor)
     if not network or not network.currentNode():
         return
     
     parent = network.currentNode().parent()
 
+    animated_nodes = []
     for node in parent.children():
         for parm in node.parms():
             if parm.keyframes():  # Check for actual keyframes
-                node.setColor(user_color)
+                animated_nodes.append(node)
                 break
+
+    if not animated_nodes:
+        hou.ui.displayMessage("No animated nodes found")
+        return
+
+    user_color = hou.ui.selectColor()
+    if user_color is None:
+        return
+
+    for node in animated_nodes:
+        node.setColor(user_color)


### PR DESCRIPTION
Implement a check to notify users when no keyframes or animated nodes are found before proceeding with colorization.